### PR TITLE
Improve Ghostty script error handling

### DIFF
--- a/finder-to-ghostty/finder-to-ghostty.sh
+++ b/finder-to-ghostty/finder-to-ghostty.sh
@@ -1,3 +1,11 @@
 #!/bin/bash
 
-open -a Ghostty "$FINDER_PATH"
+if [ -z "$FINDER_PATH" ]; then
+  echo "Error: FINDER_PATH environment variable is not set." >&2
+  exit 1
+fi
+
+if ! open -a Ghostty "$FINDER_PATH"; then
+  echo "Failed to open Ghostty. Ensure Ghostty is installed and accessible." >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add checks for `FINDER_PATH` in `finder-to-ghostty.sh`
- surface errors if Ghostty fails to open

## Testing
- `bash finder-to-ghostty/finder-to-ghostty.sh` *(fails: FINDER_PATH not set)*
- `FINDER_PATH=/tmp bash finder-to-ghostty/finder-to-ghostty.sh` *(fails: open not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e0e85d7b08322b54e9b5737545f51